### PR TITLE
Fix drawer toggle and directly use openURL

### DIFF
--- a/template/src/layouts/default.vue
+++ b/template/src/layouts/default.vue
@@ -1,6 +1,5 @@
 <template>
   <q-layout
-    ref="layout"
     view="lHh Lpr fff"
     :left-class="{'bg-grey-2': true}"
   >
@@ -8,7 +7,7 @@
       <q-toolbar color="primary" glossy>
         <q-btn
           flat
-          @click="$refs.layout.toggleLeft()"
+          @click="leftDrawerOpen = !leftDrawerOpen"
         >
           <q-icon name="menu" />
         </q-btn>
@@ -20,26 +19,26 @@
       </q-toolbar>
     </q-layout-header>
 
-    <q-layout-drawer>
+    <q-layout-drawer v-model="leftDrawerOpen">
       <q-list no-border link inset-delimiter>
         <q-list-header>Essential Links</q-list-header>
-        <q-item @click="launch('http://quasar-framework.org')">
+        <q-item @click="openURL('http://quasar-framework.org')">
           <q-item-side icon="school" />
           <q-item-main label="Docs" sublabel="quasar-framework.org" />
         </q-item>
-        <q-item @click="launch('https://nuxtjs.org/')">
+        <q-item @click="openURL('https://nuxtjs.org/')">
           <q-item-side icon="school" />
           <q-item-main label="Nuxt.js Docs" sublabel="nuxtjs.org" />
         </q-item>
-        <q-item @click="launch('http://forum.quasar-framework.org')">
+        <q-item @click="openURL('http://forum.quasar-framework.org')">
           <q-item-side icon="record_voice_over" />
           <q-item-main label="Forum" sublabel="forum.quasar-framework.org" />
         </q-item>
-        <q-item @click="launch('https://gitter.im/quasarframework/Lobby')">
+        <q-item @click="openURL('https://gitter.im/quasarframework/Lobby')">
           <q-item-side icon="chat" />
           <q-item-main label="Gitter Channel" sublabel="Quasar Lobby" />
         </q-item>
-        <q-item @click="launch('https://twitter.com/quasarframework')">
+        <q-item @click="openURL('https://twitter.com/quasarframework')">
           <q-item-side icon="rss feed" />
           <q-item-main label="Twitter" sublabel="@quasarframework" />
         </q-item>
@@ -56,10 +55,13 @@
 import { openURL } from 'quasar'
 
 export default {
-  methods: {
-    launch (url) {
-      openURL(url)
+  data () {
+    return {
+      leftDrawerOpen: false
     }
+  },
+  methods: {
+    openURL
   }
 }
 </script>


### PR DESCRIPTION
Header was not changed on purpose because it should default to visible

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
