### PR TITLE
Show message and redirect to global help if command is not present

### DIFF
--- a/quasar-application/bin/qapp
+++ b/quasar-application/bin/qapp
@@ -10,23 +10,29 @@ process.on('unhandledRejection', err => {
   console.error(pe.render(err))
 })
 
-const commands = new Set([
+const commands = [
   'dev',
   'build',
   'mode',
   'version',
   'help'
-])
+]
 
 let cmd = process.argv[2]
 
 if (cmd) {
-  if (commands.has(cmd)) {
+  if (commands.includes(cmd)) {
     process.argv.splice(2, 1)
   }
   else {
-    require('../lib/helpers/logger')('app', 'red')(`Unknown command "${cmd}"`)
-    process.exit(1)
+    if (cmd.indexOf('-') === 0) {
+      require('../lib/helpers/logger')('app', 'red')(`You must provide one command from [${ commands.join('|') }]`)
+      cmd = 'help'
+    }
+    else {
+      require('../lib/helpers/logger')('app', 'red')(`Unknown command "${ cmd }"`)
+      process.exit(1)
+    }
   }
 }
 else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
