### PR TITLE
Reorder CSS loading order

### DIFF
--- a/quasar-application/templates/app/entry.js
+++ b/quasar-application/templates/app/entry.js
@@ -37,13 +37,13 @@ import Quasar<%= QImports || '' %> from 'quasar'
 Vue.config.productionTip = false
 import App from '~/App'
 
-require(`~/themes/app.<%= ctx.themeName %>.styl`)
-
 <%
 extras && extras.filter(asset => asset).forEach(asset => {
 %>
 require('quasar-extras/<%= asset %>')
 <% }) %>
+
+require(`~/themes/app.<%= ctx.themeName %>.styl`)
 
 <% css && css.filter(css => css).forEach(asset => { %>
 require('~/css/<%= asset %>')


### PR DESCRIPTION
Theme should be loaded after extras and before local CSS

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
